### PR TITLE
Will now boot to Rhasspy

### DIFF
--- a/configs/apps/satellite/hooks/Dockerfile
+++ b/configs/apps/satellite/hooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jarvyj/homeintent-satellite:main
+FROM ghcr.io/jarvyj/rhasspy-satellite:main
 
 FROM scratch
 COPY --from=0 /usr/lib/rhasspy /

--- a/configs/apps/satellite/resources/rpi/cmdline.txt
+++ b/configs/apps/satellite/resources/rpi/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 console=serial0,115200 console=ttyAMA0,115200 root=/dev/initrd ro ramdisk_size=100000 net.ifnames=0 elevator=deadline dwc_otg.lpm_enable=0 fixrtc
+console=tty1 console=serial0,115200 console=ttyAMA0,115200 root=/dev/initrd ro ramdisk_size=100000 net.ifnames=0 elevator=deadline dwc_otg.lpm_enable=0 fixrtc quiet

--- a/configs/apps/satellite/resources/rpi/config.txt
+++ b/configs/apps/satellite/resources/rpi/config.txt
@@ -1,11 +1,4 @@
-# For more options and information see
-# http://rpf.io/configtxt
-# Some settings may impact device functionality.
-
-# This is the default Skiff config.txt.
-# You should customize it to your own needs.
-# Create a Skiff config, and copy this file to:
-# my/config/resources/rpi/config.txt
+# this is a slightly optimized rhasspy-satellite config.txt!
 
 kernel=zImage
 initramfs rootfs.cpio.lz4
@@ -15,24 +8,8 @@ initramfs rootfs.cpio.lz4
 start_file=start.elf
 fixup_file=fixup.dat
 
-# Enable GPIO features
-dtparam=i2c_arm=on
-dtparam=spi=on
-# dtparam=i2s=on
-
-# Add module parameters to the end of the dtoverlay line,
-# e.g. dtoverlay=lirc-rpi,gpio_in_pin=16,gpio_in_pull=high
-# dtoverlay=lirc-rpi
-
 # disable bt and enable uart on PL011 (UART0)
 dtoverlay=disable-bt
-
-# w1-gpio
-# If you require the external pullup
-# dtoverlay=w1-gpio-pullup,gpiopin=x,pullup=y
-# otherwise
-# dtoverlay=w1-gpio-pullup,gpiopin=x
-# (where x and y are gpios).
 
 # Audio card
 dtparam=audio=on
@@ -42,21 +19,10 @@ dtparam=audio=on
 # dtoverlay=iqaudio-dac
 # dtoverlay=iqaudio-dacplus
 
-# Heartbeat LED
-# dtparam=act_led_trigger=heartbeat
-
-# Allow the board to draw additional voltage.
-# Note: this sets a permanent overclock canary bit on the Pi.
-# over_voltage=4
-
-# Forces the CPU to run at maximum clock speed (expect heat)
-# force_turbo=1
-
-# Forces CPU to run in turbo for initial seconds
-# initial_turbo=45
-
 # dont wait! defaults to 1s.
 boot_delay=0
+disable_splash=1
+dtoverlay=sdtweak,overclock_50=80
 
 [pi4]
 # dtoverlay=vc4-kms-v3d-pi4
@@ -71,6 +37,3 @@ disable_overscan=1
 hdmi_drive=2
 gpu_mem=16
 
-# skiff extension files (todo)
-# include skiff-boardcfg.txt
-# include skiff-usercfg.txt

--- a/configs/apps/satellite/root_overlay/usr/lib/systemd/system/multi-user.target.wants/rhasspy-satellite.service
+++ b/configs/apps/satellite/root_overlay/usr/lib/systemd/system/multi-user.target.wants/rhasspy-satellite.service
@@ -1,0 +1,1 @@
+../rhasspy-satellite.service

--- a/configs/apps/satellite/root_overlay/usr/lib/systemd/system/rhasspy-satellite.service
+++ b/configs/apps/satellite/root_overlay/usr/lib/systemd/system/rhasspy-satellite.service
@@ -5,7 +5,8 @@ After=network.target
 Wants=network.target
 
 [Service]
-Type=forking
+Type=simple
+Environment="PATH=/usr/lib/rhasspy/bin:/usr/bin:/usr/sbin"
 ExecStart=/usr/lib/rhasspy/bin/rhasspy-voltron --user-profiles /mnt/persist/profiles --profile en
 Restart=on-failure
 RestartSec=15


### PR DESCRIPTION
 * uses the new rhasspy-satellite docker instead of the old homeintent-satellite
 * rhasspy now boots as a service
 * minor tweaks in splash screens and stuff (i might revert some of these...)